### PR TITLE
Redesign/rewrite slider control

### DIFF
--- a/src/lascaux-ui/DrawletApp.module.css
+++ b/src/lascaux-ui/DrawletApp.module.css
@@ -29,6 +29,7 @@
   z-index: 1;
   color: #fff;
   background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(5px);
 }
 .left {
   display: flex;

--- a/src/lascaux-ui/DrawletApp.tsx
+++ b/src/lascaux-ui/DrawletApp.tsx
@@ -62,6 +62,8 @@ type Props = {
   drawingModel: DrawingModel;
 };
 
+const numberFormat = new Intl.NumberFormat();
+
 export function DrawletApp({ drawingId, dna, drawingModel }: Props) {
   const drawletContainerRef = useRef<HTMLDivElement>(null);
   const [updateObjectState, setUpdateObject] = useState<LascauxUiState | null>(
@@ -168,84 +170,6 @@ export function DrawletApp({ drawingId, dna, drawingModel }: Props) {
     }
   }, [canvasInstance, redo]);
 
-  const sizeSlider = useMemo(
-    () => (
-      <Slider
-        min={1}
-        max={100}
-        value={brushSize}
-        onChange={setTempBrushSize}
-        onAfterChange={setBrushSize}
-      />
-    ),
-    [brushSize, setBrushSize, setTempBrushSize],
-  );
-  const flowSlider = useMemo(
-    () => (
-      <Slider
-        min={0.01}
-        max={1.0}
-        step={0.01}
-        value={brushFlow}
-        onChange={setTempBrushFlow}
-        onAfterChange={setBrushFlow}
-      />
-    ),
-    [brushFlow, setBrushFlow, setTempBrushFlow],
-  );
-  const spacingSlider = useMemo(
-    () => (
-      <Slider
-        min={0.005}
-        max={0.25}
-        step={0.005}
-        value={brushSpacing}
-        onChange={setTempBrushSpacing}
-        onAfterChange={setBrushSpacing}
-      />
-    ),
-    [brushSpacing, setBrushSpacing, setTempBrushSpacing],
-  );
-  const hardnessSlider = useMemo(
-    () => (
-      <Slider
-        min={0.0}
-        max={1.0}
-        step={0.01}
-        value={brushHardness}
-        onChange={setTempBrushHardness}
-        onAfterChange={setBrushHardness}
-      />
-    ),
-    [brushHardness, setBrushHardness, setTempBrushHardness],
-  );
-  const zoomSlider = useMemo(
-    () => (
-      <Slider
-        min={0.1}
-        step={0.05}
-        marks={[1]}
-        max={5}
-        value={transform.scale}
-        onChange={setScale}
-      />
-    ),
-    [setScale, transform.scale],
-  );
-  const playbackSlider = useMemo(
-    () => (
-      <Slider
-        min={0}
-        step={1}
-        max={strokeCount}
-        value={cursor}
-        onChange={seek}
-        className={styles.cursorSlider}
-      />
-    ),
-    [strokeCount, cursor, seek],
-  );
-
   const onSelectLayer = useCallback(
     (layerId: string) => {
       canvasInstance.mutateMode((draft) => {
@@ -323,7 +247,16 @@ export function DrawletApp({ drawingId, dna, drawingModel }: Props) {
             alt={playing ? 'Pause' : 'Play'}
           />
         </Button>
-        {playbackSlider}
+        <Slider
+          label="Drawing Playback"
+          min={0}
+          step={1}
+          max={strokeCount}
+          value={cursor}
+          valueLabel={numberFormat.format(cursor)}
+          onChange={seek}
+          className={styles.cursorSlider}
+        />
         <Button disabled={undo === undefined} onClick={onUndo}>
           <Icon file={UndoIcon} alt="Undo icon" />
           Undo
@@ -346,34 +279,55 @@ export function DrawletApp({ drawingId, dna, drawingModel }: Props) {
           </label>
         </div>
         <ColorChooser color={mode.color} onChangeColor={onChangeColor} />
-        <label className={styles.toolLabel}>
-          Size <span className={styles.value}>{brushSize}</span>
-        </label>
-        {sizeSlider}
-        <label className={styles.toolLabel}>
-          Opacity{' '}
-          <span className={styles.value}>{(brushFlow * 100).toFixed(0)}%</span>
-        </label>
-        {flowSlider}
-        <label className={styles.toolLabel}>
-          Spacing{' '}
-          <span className={styles.value}>{brushSpacing.toFixed(2)}x</span>
-        </label>
-        {spacingSlider}
-        <label className={styles.toolLabel}>
-          Hardness{' '}
-          <span className={styles.value}>
-            {(brushHardness * 100).toFixed(0)}%
-          </span>
-        </label>
-        {hardnessSlider}
-        <label className={styles.toolLabel}>
-          Zoom{' '}
-          <span className={styles.value}>
-            {(transform.scale * 100).toFixed(0)}%
-          </span>
-        </label>
-        {zoomSlider}
+        <Slider
+          label="Size"
+          min={1}
+          max={100}
+          value={brushSize}
+          valueLabel={`${brushSize}px`}
+          onChange={setTempBrushSize}
+          onAfterChange={setBrushSize}
+        />
+        <Slider
+          label="Opacity"
+          min={0.01}
+          max={1.0}
+          step={0.01}
+          value={brushFlow}
+          valueLabel={`${(brushFlow * 100).toFixed(0)}%`}
+          onChange={setTempBrushFlow}
+          onAfterChange={setBrushFlow}
+        />
+        <Slider
+          label="Spacing"
+          min={0.005}
+          max={0.25}
+          step={0.005}
+          value={brushSpacing}
+          valueLabel={`${brushSpacing.toFixed(2)}x`}
+          onChange={setTempBrushSpacing}
+          onAfterChange={setBrushSpacing}
+        />
+        <Slider
+          label="Hardness"
+          min={0.0}
+          max={1.0}
+          step={0.01}
+          value={brushHardness}
+          valueLabel={`${(brushHardness * 100).toFixed(0)}%`}
+          onChange={setTempBrushHardness}
+          onAfterChange={setBrushHardness}
+        />
+        <Slider
+          label="Zoom"
+          min={0.1}
+          step={0.05}
+          marks={[1]}
+          max={5}
+          value={transform.scale}
+          valueLabel={`${(transform.scale * 100).toFixed(0)}%`}
+          onChange={setScale}
+        />
         <label className={styles.toolLabel}>Layers</label>
         <span className={styles.layers}>
           <LayerList

--- a/src/pages/modules/Changelog.tsx
+++ b/src/pages/modules/Changelog.tsx
@@ -5,6 +5,11 @@ import styles from './Changelog.module.css';
 export function Changelog() {
   return (
     <div className={styles.changelog}>
+      <h3>2020-07-12</h3>
+      <ul>
+        <li>Redesigned sliders with better iPad support</li>
+      </ul>
+
       <h3>2020-07-08</h3>
       <ul>
         <li>New internal drawing format</li>

--- a/src/ui/Slider.module.css
+++ b/src/ui/Slider.module.css
@@ -1,134 +1,60 @@
 .slider {
-  display: block;
   width: 100%;
-  appearance: none;
-  background: transparent;
+  position: relative;
+  border: solid 1px #888;
+  background: linear-gradient(
+    to right,
+    rgba(0, 0, 0, 0.75),
+    rgba(255, 255, 255, 0.75)
+  );
+  backdrop-filter: blur(10px);
+  border-radius: 2px;
   cursor: pointer;
-  margin: 0 0;
-  padding: 5px 0;
+  margin: 2px 0;
+  outline: none;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
 }
 .slider:focus {
-  outline: none;
+  border-color: #fff;
 }
 
-/**
- Slider track (the line behind the slider)
- */
-.slider::-webkit-slider-runnable-track {
-  width: 100%;
-  height: 7px;
-  cursor: pointer;
-  box-shadow: 1px 1px 1px #000000;
+.thumb,
+.mark {
+  position: absolute;
+}
+.thumb {
+  top: 0;
+  bottom: 0;
   background: #fff;
-  border-radius: 7px;
-  border: 0.2px solid #010101;
+  width: 2px;
+  border-right: solid 1px #000;
 }
-.slider::-moz-range-track {
-  width: 100%;
-  height: 7px;
-  cursor: pointer;
-  box-shadow: 1px 1px 1px #000000;
-  background: #fff;
-  border-radius: 7px;
-  border: 0.5px solid #010101;
+.mark {
+  bottom: 0;
+  height: 4px;
+  background: #ccc;
+  width: 2px;
+  border-right: solid 1px #000;
 }
-.slider::-ms-track {
-  width: 100%;
-  height: 8.4px;
-  cursor: pointer;
-  background: transparent;
-  border-color: transparent;
-  border-width: 16px 0;
-  color: transparent;
+.label,
+.valueLabel {
+  flex-grow: 1;
+  flex-shrink: 0;
+  z-index: 1;
+  padding: 2px 4px;
 }
-.slider::-ms-fill-lower {
-  background: #2a6495;
-  border: 0.2px solid #010101;
-  border-radius: 2.6px;
-  box-shadow: 1px 1px 1px #000000, 0 0 1px #0d0d0d;
+.label {
+  color: #fff;
+  font-size: 0.9em;
+  text-shadow: 0 0 2px #000;
 }
-.slider::-ms-fill-upper {
-  background: #3071a9;
-  border: 0.2px solid #010101;
-  border-radius: 2.6px;
-  box-shadow: 1px 1px 1px #000000, 0 0 1px #0d0d0d;
-}
-
-/*
- Slider thumb (the part you click and drag)
- */
-.slider::-webkit-slider-thumb {
-  box-shadow: 1px 1px 1px #000000, 0 0 1px #0d0d0d;
-  border: 1px solid #000000;
-  height: 18px;
-  width: 18px;
-  border-radius: 18px;
-  background: #ffffff;
-  cursor: pointer;
-  appearance: none;
-  margin-top: -6px;
-}
-.slider::-moz-range-thumb {
-  box-shadow: 1px 1px 1px #000000, 0 0 1px #0d0d0d;
-  border: 1px solid #000000;
-  height: 18px;
-  width: 18px;
-  border-radius: 18px;
-  background: #ffffff;
-  cursor: pointer;
-  appearance: none;
-  margin-top: -6px;
-}
-.slider::-ms-thumb {
-  box-shadow: 1px 1px 1px #000000, 0 0 1px #0d0d0d;
-  border: 1px solid #000000;
-  height: 36px;
-  width: 16px;
-  border-radius: 3px;
-  background: #ffffff;
-  cursor: pointer;
-}
-
-/*
- Tweaks when slider is focused
- */
-.slider:focus::-webkit-slider-runnable-track {
-  background: var(--accent-color);
-}
-.slider:focus::-moz-range-track {
-  background: var(--accent-color);
-}
-.slider:focus::-ms-fill-lower {
-  background: var(--accent-color);
-}
-.slider:focus::-ms-fill-upper {
-  background: var(--accent-color);
-}
-
-/*
- Tweaks when slider is hovered
- */
-.slider:hover::-webkit-slider-runnable-track {
-  border: 0.5px solid #ccc;
-}
-.slider:hover::-webkit-slider-thumb {
-  border: 0.5px solid #ccc;
-}
-.slider:hover::-moz-range-track {
-  border: 0.5px solid #ccc;
-}
-.slider:hover::-moz-range-thumb {
-  border: 0.5px solid #ccc;
-}
-.slider:focus:hover::-webkit-slider-runnable-track {
-  border: 0.5px solid var(--accent-color);
-}
-.slider:focus:hover::-webkit-slider-thumb {
-  border: 0.5px solid var(--accent-color);
-}
-.slider:focus:hover::-moz-range-track {
-  border: 0.5px solid var(--accent-color);
-}
-.slider:focus:hover::-moz-range-thumb {
-  border: 0.5px solid var(--accent-color);
+.valueLabel {
+  font-size: 0.8em;
+  text-shadow: 0 0 2px #fff;
+  vertical-align: center;
+  color: #000;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
 }


### PR DESCRIPTION
- inspired by original lascaux sketch slider
- better iPad/touch support
- supports focus, keyboard, pointer events
- much more compact: integrates label
- aria support (hope I did it right)

<img width="143" alt="image" src="https://user-images.githubusercontent.com/21952/87260411-9ee90100-c466-11ea-8a8c-37533713268c.png">

Original Lascaux Sketch sliders for comparison:
<img width="167" alt="image" src="https://user-images.githubusercontent.com/21952/87260424-ac05f000-c466-11ea-8340-bb72e7267647.png">

Fixes #68 